### PR TITLE
Log observer crashes when too many files are being watched

### DIFF
--- a/roxconnector_plugin/log_observer.js
+++ b/roxconnector_plugin/log_observer.js
@@ -117,14 +117,19 @@ function watch_file(file) {
 				let position = stats.size;
 				this.watcher = fs.watch(file, {}, (eventType, _) => {
 					if (eventType === 'change') {
-						fs.read(fd, this.buffer, offset, this.bufsize - offset, position, (err, bytesRead) => {
-							position += bytesRead;
-							ret = read_lines(this.buffer.toString('utf-8', 0, offset + bytesRead));
-							offset = this.buffer.write(ret.rest);
-							this.subscribers.forEach((s) => {
-								s.cb(ret.lines);
-							});
-						});
+					    try {
+                            fs.read(fd, this.buffer, offset, this.bufsize - offset, position, (err, bytesRead) => {
+                                position += bytesRead;
+                                ret = read_lines(this.buffer.toString('utf-8', 0, offset + bytesRead));
+                                offset = this.buffer.write(ret.rest);
+                                this.subscribers.forEach((s) => {
+                                    s.cb(ret.lines);
+                                });
+                            });
+					    }
+					    catch(e) {
+					        this.logger.error({error: e, file: file}, 'Unable to watch log file!');
+					    }
 					}
 				});
 				this.watcher.on('error', (err) => { console.error(err); });


### PR DESCRIPTION
The following error is thrown when too many files are being watched (see [Stackoverflow](https://stackoverflow.com/questions/22475849/node-js-what-is-enospc-error-and-how-to-solve)):

```
fs.js:1384
    throw error;
    ^

Error: watch ../logs/roxconnector.log ENOSPC
    at _errnoException (util.js:1022:11)
    at FSWatcher.start (fs.js:1382:19)
    at Object.fs.watch (fs.js:1408:11)
    at fs.stat ([...]/roxcomposer/build/roxcomposer-demo-0.4.1.dev2+getroxcomposerlogs27/api-server/plugins/log_observer.js:95:23)
    at FSReqWrap.oncomplete (fs.js:153:5)
```

This error (and other read related errors) have been caught and logged. More specific error handling could be complicated.