### PR TITLE
Validate service parameters and log errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.4.3
+
+## New
+
+* Check parameters of a service ("ip", "port") for validity and throw a `roxcomposer.exceptions.ConfigError` if parameters are invalid
+
+## Fixed 
+
+* Fixed crash when trying to bind to an invalid IP address specified in service parameters
+
 # v0.4.2
 
 ## New

--- a/roxcomposer/base_service.py
+++ b/roxcomposer/base_service.py
@@ -91,6 +91,8 @@ class BaseService:
 
         self.logger = LoggingClass(self.params['name'], **logger_params)
 
+        # Read service parameters
+
         if self.params is None:
             # logger need the service name
             self.params['name'] = 'not defined'
@@ -106,6 +108,21 @@ class BaseService:
             if param not in self.params:
                 self.logger.critical('BaseService.__init__() - "' + param + '" is required in params.')
                 raise exceptions.ParameterMissing('BaseService.__init__() - "' + param + '" is required in params.')
+
+        # Validate service parameters
+
+        if not isinstance(self.params['ip'], str):
+            self.logger.critical('BaseService.__init__() - "ip" in params is not a string.')
+            raise exceptions.ConfigError('BaseService.__init__() - "ip" in params is not a string.')
+        if not isinstance(self.params['port'], int):
+            self.logger.critical('BaseService.__init__() - "port" in params is not an int.')
+            raise exceptions.ConfigError('BaseService.__init__() - "port" in params is not an int.')
+
+        try:
+            socket.inet_aton(self.params['ip'])
+        except socket.error:
+            self.logger.critical('BaseService.__init__() - "ip" in params is not a valid IP address.')
+            raise exceptions.ConfigError('BaseService.__init__() - "ip" in params is not a valid IP address.')
 
         # initialize monitoring
         monitoring_params = {

--- a/roxcomposer/base_service.py
+++ b/roxcomposer/base_service.py
@@ -140,11 +140,11 @@ class BaseService:
         self.logger.info('started', **self.params)
         self.roxcomposer_message = roxcomposer_message.Message()
 
-    # need to be overwritten by inhertied classes.
+    # need to be overwritten by inherited classes.
     def on_message(self, msg, msg_id, parameters=None):
         pass
 
-    # need to be overwritten by inherited classes. This funciton gets the whole message object as a ROXcomposerMessage.
+    # need to be overwritten by inherited classes. This function gets the whole message object as a ROXcomposerMessage.
     # If you just need the payload's message, please user on_message instead.
     def on_message_ext(self, extended_msg):
         pass
@@ -250,7 +250,8 @@ class BaseService:
                 try:
                     me = self.roxcomposer_message.pop_service()
                 except IndexError:
-                    self.logger.warn('Received message with empty pipeline - any additional parameters meant for this service are lost')
+                    self.logger.warn('Received message with empty pipeline - any additional parameters meant for this '
+                                     'service are lost')
                     me = roxcomposer_message.Service(ip, port)
 
                 self.logger.debug('ROXcomposerMessage received: ' + self.roxcomposer_message.__str__())

--- a/roxcomposer/tests/base_service.py
+++ b/roxcomposer/tests/base_service.py
@@ -113,6 +113,27 @@ class TestBaseService(unittest.TestCase):
 
         self.assertRaises(exceptions.ParameterMissing, base_service.BaseService, self.test_params_2)
 
+        # test invalid parameters
+        self.assertRaises(exceptions.ConfigError, base_service.BaseService, {
+            'ip': '127.0.0.1',
+            'port': '4711',
+            'name': 'fancy-service',
+            "logging": {
+                "level": "INFO",
+                "logpath": "/dev/null"
+            }
+        })
+
+        self.assertRaises(exceptions.ConfigError, base_service.BaseService, {
+            'ip': '127.0.999.1',
+            'port': 4711,
+            'name': 'fancy-service',
+            "logging": {
+                "level": "INFO",
+                "logpath": "/dev/null"
+            }
+        })
+
         # test initiation with params
         bs_with_params = base_service.BaseService({
             'ip': '127.0.0.1',

--- a/roxcomposer/tests/base_service.py
+++ b/roxcomposer/tests/base_service.py
@@ -228,7 +228,7 @@ class TestBaseService(unittest.TestCase):
     @unittest.skipIf('SKIP_TEMPDIR_TEST' in os.environ, "tempdir issues")
     def test_config_loading(self):
         os.environ['DROXIT_ROXCOMPOSER_CONFIG'] = '/bogus/path/from/hell.json'
-        self.assertRaises(exceptions.ConfigError, base_service.BaseService, { "service_key": "nevermind" })
+        self.assertRaises(exceptions.ConfigError, base_service.BaseService, {"service_key": "nevermind"})
 
         with TemporaryDirectory() as tdir:
             confname = os.path.join(tdir, "config.json")
@@ -241,14 +241,14 @@ class TestBaseService(unittest.TestCase):
 
             os.environ['DROXIT_ROXCOMPOSER_CONFIG'] = confname
 
-            self.assertRaises(exceptions.ParameterMissing, base_service.BaseService, { "service_key": "nevermind" })
+            self.assertRaises(exceptions.ParameterMissing, base_service.BaseService, {"service_key": "nevermind"})
             s = base_service.BaseService({"service_key": "service.dummy"})
             self.assertDictEqual(s.params, self.test_params_1)
 
             f = open(confname, "w")
             f.write('this is no proper JSON')
             f.close()
-            self.assertRaises(exceptions.ConfigError, base_service.BaseService, { "service_key": "nevermind" })
+            self.assertRaises(exceptions.ConfigError, base_service.BaseService, {"service_key": "nevermind"})
 
 
 if __name__ == '__main__':

--- a/roxcomposer/tests/logging.py
+++ b/roxcomposer/tests/logging.py
@@ -37,7 +37,7 @@ class TestLogging(unittest.TestCase):
     def test_basic_logger_fails(self):
         params = {
             'name': 'logger_should_fail',
-            'ip': 'not important',
+            'ip': '127.0.0.1',
             'port': 3,
             'logging': {
                 'level': 'WARNING',
@@ -63,7 +63,7 @@ class TestLogging(unittest.TestCase):
 
             params = {
                 'name': 'logging_logtest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'logging': {
                     'level': 'DEBUG',
@@ -123,7 +123,7 @@ class TestLogging(unittest.TestCase):
 
             params = {
                 'name': 'logtest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'logging': {
                     'level': 'DEBUG',
@@ -146,7 +146,7 @@ class TestLogging(unittest.TestCase):
 
             params = {
                 'name': 'logtest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'logging': {
                     'level': 'DEBUG',
@@ -162,7 +162,7 @@ class TestLogging(unittest.TestCase):
 
             params = {
                 'name': 'logtest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'logging': {
                     'level': 'DEBUG',
@@ -178,7 +178,7 @@ class TestLogging(unittest.TestCase):
 
             params = {
                 'name': 'logtest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'logging': {
                     'level': 'DEBUG',

--- a/roxcomposer/tests/monitoring.py
+++ b/roxcomposer/tests/monitoring.py
@@ -35,11 +35,12 @@ from roxcomposer import exceptions
 
 
 class TestMonitoring(unittest.TestCase):
- 
+
     @unittest.skipIf('SKIP_TEMPDIR_TEST' in os.environ, "tempdir issues")
     def test_basic_monitoring(self):
         self.assertRaises(exceptions.ParameterMissing, basic_monitoring.BasicMonitoring)
-        self.assertRaises(exceptions.ConfigError, basic_monitoring.BasicMonitoring, filename='/not/even/remotely/viable')
+        self.assertRaises(exceptions.ConfigError, basic_monitoring.BasicMonitoring,
+                          filename='/not/even/remotely/viable')
         self.assertRaises(exceptions.ParameterMissing, basic_monitoring.BasicReporting)
         self.assertRaises(exceptions.ConfigError, basic_monitoring.BasicReporting, filename='/not/even/remotely/viable')
 

--- a/roxcomposer/tests/monitoring.py
+++ b/roxcomposer/tests/monitoring.py
@@ -92,7 +92,7 @@ class TestMonitoring(unittest.TestCase):
 
             params = {
                 'name': 'monitortest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'logging': {
                     'level': 'DEBUG',
@@ -119,7 +119,7 @@ class TestMonitoring(unittest.TestCase):
 
             params = {
                 'name': 'monitortest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'monitoring': {
                     'filename': monitor_path,
@@ -131,7 +131,7 @@ class TestMonitoring(unittest.TestCase):
 
             params = {
                 'name': 'monitortest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'monitoring': {
                     'filename': monitor_path,
@@ -143,7 +143,7 @@ class TestMonitoring(unittest.TestCase):
 
             params = {
                 'name': 'monitortest',
-                'ip': 'not important',
+                'ip': '127.0.0.1',
                 'port': 7,
                 'monitoring': {
                     'filename': monitor_path,


### PR DESCRIPTION
Required service parameters are now being checked for datatype and validity of the IP address and logs errors in case of invalid entries.

Check if Issue #102 is being closed by this fix.